### PR TITLE
Use `python-binary-memcached` instead of `pylibmc`

### DIFF
--- a/django_tasklist/settings.py
+++ b/django_tasklist/settings.py
@@ -132,33 +132,15 @@ def get_cache():
     password = os.environ['MEMCACHIER_PASSWORD']
     return {
       'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'BACKEND': 'django_bmemcached.memcached.BMemcached',
         # TIMEOUT is not the connection timeout! It's the default expiration
         # timeout that should be applied to keys! Setting it to `None`
         # disables expiration.
         'TIMEOUT': None,
         'LOCATION': servers,
         'OPTIONS': {
-          'binary': True,
           'username': username,
           'password': password,
-          'behaviors': {
-            # Enable faster IO
-            'no_block': True,
-            'tcp_nodelay': True,
-            # Keep connection alive
-            'tcp_keepalive': True,
-            # Timeout settings
-            'connect_timeout': 2000, # ms
-            'send_timeout': 750 * 1000, # us
-            'receive_timeout': 750 * 1000, # us
-            '_poll_timeout': 2000, # ms
-            # Better failover
-            'ketama': True,
-            'remove_failed': 1,
-            'retry_timeout': 2,
-            'dead_timeout': 30,
-          }
         }
       }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 dj-database-url==0.5.0
-Django==2.1
+Django==2.2.7
+django-bmemcached==0.2.4
 django-heroku==0.3.1
-gunicorn==19.9.0
-psycopg2==2.7.5
-pylibmc==1.5.2
-pytz==2018.5
+gunicorn==20.0.2
+psycopg2==2.8.4
+python-binary-memcached==0.28.0
+pytz==2019.3
 whitenoise==4.0


### PR DESCRIPTION
## Use `python-binary-memcached` instead of `pylibmc`

This PR replaces `pylibmc` with the `django-bmemcached` backend, which uses the pure Python library `python-binary-memcached`.

It also updates dependencies.